### PR TITLE
expose a method for getting the the string from MustBeStr

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,8 +1,5 @@
 use crate::string::RetrieveString;
 use core::fmt::{self, Debug};
-use core::mem;
-use core::slice;
-use core::str;
 
 impl<const V: char> Debug for crate::MustBeChar<V> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -90,6 +87,8 @@ impl<const V: bool> Debug for crate::MustBeBool<V> {
 
 impl<V: RetrieveString> Debug for crate::MustBeStr<V> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        Self::with_str(|s| write!(formatter, "MustBe!({:?})", s))
+        crate::get_str!(s = Self);
+
+        write!(formatter, "MustBe!({:?})", s)
     }
 }

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -1,9 +1,6 @@
 use crate::format;
 use crate::string::RetrieveString;
 use core::fmt::{self, Write as _};
-use core::mem;
-use core::slice;
-use core::str;
 use serde::de::{Deserialize, Deserializer, Error, Unexpected, Visitor};
 
 impl<'de, const V: char> Deserialize<'de> for crate::MustBeChar<V> {
@@ -624,10 +621,10 @@ impl<'de, V: RetrieveString> Deserialize<'de> for crate::MustBeStr<V> {
             }
         }
 
-        Self::with_str(|s| {
-            deserializer
-                .deserialize_any(MustBeStrVisitor(s))
-                .map(|()| crate::MustBeStr)
-        })
+        crate::get_str!(s = Self);
+
+        deserializer
+            .deserialize_any(MustBeStrVisitor(s))
+            .map(|()| crate::MustBeStr)
     }
 }

--- a/src/partial_ord.rs
+++ b/src/partial_ord.rs
@@ -1,9 +1,5 @@
 use crate::string::RetrieveString;
-use crate::MustBeStr::MustBeStr;
 use core::cmp::Ordering;
-use core::mem;
-use core::slice;
-use core::str;
 
 impl<const V: char, const W: char> PartialOrd<crate::MustBeChar<W>> for crate::MustBeChar<V> {
     fn partial_cmp(&self, _: &crate::MustBeChar<W>) -> Option<Ordering> {
@@ -95,8 +91,9 @@ where
     W: RetrieveString,
 {
     fn partial_cmp(&self, _: &crate::MustBeStr<W>) -> Option<Ordering> {
-        Some(Self::with_str(|s1| {
-            crate::MustBeStr::<W>::with_str(|s2| s1.cmp(s2))
-        }))
+        crate::get_str!(s1 = Self);
+        crate::get_str!(s2 = crate::MustBeStr<W>);
+
+        Some(s1.cmp(s2))
     }
 }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,7 +1,4 @@
 use crate::string::RetrieveString;
-use core::mem;
-use core::slice;
-use core::str;
 use serde::{Serialize, Serializer};
 
 impl<const V: char> Serialize for crate::MustBeChar<V> {
@@ -117,6 +114,7 @@ impl<V: RetrieveString> Serialize for crate::MustBeStr<V> {
     where
         S: Serializer,
     {
-        Self::with_str(|s| serializer.serialize_str(s))
+        crate::get_str!(s = Self);
+        serializer.serialize_str(s)
     }
 }

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,4 +1,4 @@
-use crate::{alphabet, MustBeStr::MustBeStr};
+use crate::alphabet;
 
 const TAG_CONT: u8 = 0b1000_0000;
 const TAG_TWO_B: u8 = 0b1100_0000;
@@ -117,17 +117,4 @@ where
 {
     type Type = Concat6<A::Type, B::Type, C::Type, D::Type, E::Type, F::Type>;
     const BYTES: Self::Type = Concat6(A::BYTES, B::BYTES, C::BYTES, D::BYTES, E::BYTES, F::BYTES);
-}
-
-impl<V: RetrieveString> crate::MustBeStr<V> {
-    pub fn with_str<R>(f: impl FnOnce(&str) -> R) -> R {
-        let str = unsafe {
-            str::from_utf8_unchecked(core::slice::from_raw_parts(
-                &V::BYTES as *const V::Type as *const u8,
-                core::mem::size_of::<V::Type>(),
-            ))
-        };
-
-        f(str)
-    }
 }


### PR DESCRIPTION
I have a use case where I want to be generic over the monostate Str type. and it would be useful to access the str from the type.

currently I am using Serde with a custom Serializer to achieve that result but it seems a bit complicated.



each commit is a different implementation idea.
the first one uses a method with a callback function (this one would also need some public trait to allow calling the function in an generic context)

the other on uses a macro to stack allocate the str in the current scope


I am also open to generalise this idea to the other types if that is interesting