### PR TITLE
Prefer narrowly-typed deserializers instead of `deserialize_any`

### DIFF
--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -217,7 +217,7 @@ impl<'de, const V: u8> Deserialize<'de> for crate::MustBeU8<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeU8Visitor(V))
+            .deserialize_u8(MustBeU8Visitor(V))
             .map(|()| crate::MustBeU8)
     }
 }
@@ -249,7 +249,7 @@ impl<'de, const V: u16> Deserialize<'de> for crate::MustBeU16<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeU16Visitor(V))
+            .deserialize_u16(MustBeU16Visitor(V))
             .map(|()| crate::MustBeU16)
     }
 }
@@ -281,7 +281,7 @@ impl<'de, const V: u32> Deserialize<'de> for crate::MustBeU32<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeU32Visitor(V))
+            .deserialize_u32(MustBeU32Visitor(V))
             .map(|()| crate::MustBeU32)
     }
 }
@@ -300,27 +300,6 @@ impl<'de, const V: u64> Deserialize<'de> for crate::MustBeU64<V> {
                 write!(formatter, "integer `{}` as u64", self.0)
             }
 
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
-            where
-                E: Error,
-            {
-                Err(E::invalid_type(Unexpected::Unsigned(v as u64), &self))
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
-            where
-                E: Error,
-            {
-                Err(E::invalid_type(Unexpected::Unsigned(v as u64), &self))
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
-            where
-                E: Error,
-            {
-                Err(E::invalid_type(Unexpected::Unsigned(v as u64), &self))
-            }
-
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
             where
                 E: Error,
@@ -334,7 +313,7 @@ impl<'de, const V: u64> Deserialize<'de> for crate::MustBeU64<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeU64Visitor(V))
+            .deserialize_u64(MustBeU64Visitor(V))
             .map(|()| crate::MustBeU64)
     }
 }
@@ -372,7 +351,7 @@ impl<'de, const V: u128> Deserialize<'de> for crate::MustBeU128<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeU128Visitor(V))
+            .deserialize_u128(MustBeU128Visitor(V))
             .map(|()| crate::MustBeU128)
     }
 }
@@ -404,7 +383,7 @@ impl<'de, const V: i8> Deserialize<'de> for crate::MustBeI8<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeI8Visitor(V))
+            .deserialize_i8(MustBeI8Visitor(V))
             .map(|()| crate::MustBeI8)
     }
 }
@@ -436,7 +415,7 @@ impl<'de, const V: i16> Deserialize<'de> for crate::MustBeI16<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeI16Visitor(V))
+            .deserialize_i16(MustBeI16Visitor(V))
             .map(|()| crate::MustBeI16)
     }
 }
@@ -468,7 +447,7 @@ impl<'de, const V: i32> Deserialize<'de> for crate::MustBeI32<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeI32Visitor(V))
+            .deserialize_i32(MustBeI32Visitor(V))
             .map(|()| crate::MustBeI32)
     }
 }
@@ -487,27 +466,6 @@ impl<'de, const V: i64> Deserialize<'de> for crate::MustBeI64<V> {
                 write!(formatter, "integer `{}` as i64", self.0)
             }
 
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
-            where
-                E: Error,
-            {
-                Err(E::invalid_type(Unexpected::Signed(v as i64), &self))
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E>
-            where
-                E: Error,
-            {
-                Err(E::invalid_type(Unexpected::Signed(v as i64), &self))
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
-            where
-                E: Error,
-            {
-                Err(E::invalid_type(Unexpected::Signed(v as i64), &self))
-            }
-
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
             where
                 E: Error,
@@ -521,7 +479,7 @@ impl<'de, const V: i64> Deserialize<'de> for crate::MustBeI64<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeI64Visitor(V))
+            .deserialize_i64(MustBeI64Visitor(V))
             .map(|()| crate::MustBeI64)
     }
 }
@@ -559,7 +517,7 @@ impl<'de, const V: i128> Deserialize<'de> for crate::MustBeI128<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeI128Visitor(V))
+            .deserialize_i128(MustBeI128Visitor(V))
             .map(|()| crate::MustBeI128)
     }
 }
@@ -591,7 +549,7 @@ impl<'de, const V: bool> Deserialize<'de> for crate::MustBeBool<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeBoolVisitor(V))
+            .deserialize_bool(MustBeBoolVisitor(V))
             .map(|()| crate::MustBeBool)
     }
 }
@@ -623,7 +581,7 @@ impl<'de, V: ConstStr> Deserialize<'de> for crate::MustBeStr<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeStrVisitor(V::VALUE))
+            .deserialize_str(MustBeStrVisitor(V::VALUE))
             .map(|()| crate::MustBeStr)
     }
 }

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -108,7 +108,7 @@ impl<'de, const V: u128> Deserialize<'de> for crate::MustBePosInt<V> {
         }
 
         deserializer
-            .deserialize_any(MustBePosIntVisitor(V))
+            .deserialize_u128(MustBePosIntVisitor(V))
             .map(|()| crate::MustBePosInt)
     }
 }
@@ -185,7 +185,7 @@ impl<'de, const V: i128> Deserialize<'de> for crate::MustBeNegInt<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeNegIntVisitor(V))
+            .deserialize_i128(MustBeNegIntVisitor(V))
             .map(|()| crate::MustBeNegInt)
     }
 }
@@ -217,7 +217,7 @@ impl<'de, const V: u8> Deserialize<'de> for crate::MustBeU8<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeU8Visitor(V))
+            .deserialize_u8(MustBeU8Visitor(V))
             .map(|()| crate::MustBeU8)
     }
 }
@@ -249,7 +249,7 @@ impl<'de, const V: u16> Deserialize<'de> for crate::MustBeU16<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeU16Visitor(V))
+            .deserialize_u16(MustBeU16Visitor(V))
             .map(|()| crate::MustBeU16)
     }
 }
@@ -281,7 +281,7 @@ impl<'de, const V: u32> Deserialize<'de> for crate::MustBeU32<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeU32Visitor(V))
+            .deserialize_u32(MustBeU32Visitor(V))
             .map(|()| crate::MustBeU32)
     }
 }
@@ -334,7 +334,7 @@ impl<'de, const V: u64> Deserialize<'de> for crate::MustBeU64<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeU64Visitor(V))
+            .deserialize_u64(MustBeU64Visitor(V))
             .map(|()| crate::MustBeU64)
     }
 }
@@ -372,7 +372,7 @@ impl<'de, const V: u128> Deserialize<'de> for crate::MustBeU128<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeU128Visitor(V))
+            .deserialize_u128(MustBeU128Visitor(V))
             .map(|()| crate::MustBeU128)
     }
 }
@@ -404,7 +404,7 @@ impl<'de, const V: i8> Deserialize<'de> for crate::MustBeI8<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeI8Visitor(V))
+            .deserialize_i8(MustBeI8Visitor(V))
             .map(|()| crate::MustBeI8)
     }
 }
@@ -436,7 +436,7 @@ impl<'de, const V: i16> Deserialize<'de> for crate::MustBeI16<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeI16Visitor(V))
+            .deserialize_i16(MustBeI16Visitor(V))
             .map(|()| crate::MustBeI16)
     }
 }
@@ -468,7 +468,7 @@ impl<'de, const V: i32> Deserialize<'de> for crate::MustBeI32<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeI32Visitor(V))
+            .deserialize_i32(MustBeI32Visitor(V))
             .map(|()| crate::MustBeI32)
     }
 }
@@ -521,7 +521,7 @@ impl<'de, const V: i64> Deserialize<'de> for crate::MustBeI64<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeI64Visitor(V))
+            .deserialize_i64(MustBeI64Visitor(V))
             .map(|()| crate::MustBeI64)
     }
 }
@@ -559,7 +559,7 @@ impl<'de, const V: i128> Deserialize<'de> for crate::MustBeI128<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeI128Visitor(V))
+            .deserialize_i128(MustBeI128Visitor(V))
             .map(|()| crate::MustBeI128)
     }
 }
@@ -591,7 +591,7 @@ impl<'de, const V: bool> Deserialize<'de> for crate::MustBeBool<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeBoolVisitor(V))
+            .deserialize_bool(MustBeBoolVisitor(V))
             .map(|()| crate::MustBeBool)
     }
 }
@@ -623,7 +623,7 @@ impl<'de, V: ConstStr> Deserialize<'de> for crate::MustBeStr<V> {
         }
 
         deserializer
-            .deserialize_any(MustBeStrVisitor(V::VALUE))
+            .deserialize_str(MustBeStrVisitor(V::VALUE))
             .map(|()| crate::MustBeStr)
     }
 }

--- a/tests/deserialize_hints.rs
+++ b/tests/deserialize_hints.rs
@@ -1,0 +1,138 @@
+//! Regression tests for https://github.com/dtolnay/monostate/issues/31
+//!
+//! The fixed-width `MustBe` integer types must interoperate with deserializers
+//! whose `deserialize_any` reports an integer through a `visit_u*` method other
+//! than the one the target width uses. Self-describing formats disagree on which
+//! width `deserialize_any` reports:
+//!
+//!  - `pythonize` narrows: the integer `3` is reported via `visit_u8`, which
+//!    broke `MustBe!(3u64)`.
+//!  - `serde_json` / `cbor4ii` widen: `3` is reported via `visit_u64`, which
+//!    broke `MustBe!(3u8)`.
+//!
+//! Both are resolved by requesting the concrete serde type via the matching
+//! `deserialize_u*` hint (which format-honoring deserializers respect), and by
+//! relying on serde's default visitor forwarding (`visit_u8` -> `visit_u64`)
+//! instead of hand-rolled rejections for deserializers that ignore the hint.
+
+use monostate::MustBe;
+use serde::de::value::{Error, U8Deserializer};
+use serde::de::{Deserializer, IntoDeserializer, Visitor};
+use serde::forward_to_deserialize_any;
+use serde::Deserialize;
+
+/// How a mock deserializer's `deserialize_any` reports a non-negative integer.
+#[derive(Copy, Clone)]
+enum Mode {
+    /// Report through the *smallest* fitting `visit_u*`, like `pythonize`.
+    Narrow,
+    /// Report through `visit_u64`, like `serde_json` / `cbor4ii`.
+    Widen,
+}
+
+/// A minimal deserializer holding one non-negative integer. Its concrete
+/// `deserialize_u*` methods honor the requested width (as real self-describing
+/// formats do); only `deserialize_any` follows `mode`.
+struct IntDeserializer {
+    value: u64,
+    mode: Mode,
+}
+
+impl<'de> Deserializer<'de> for IntDeserializer {
+    type Error = Error;
+
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        match self.mode {
+            Mode::Narrow => {
+                if let Ok(v) = u8::try_from(self.value) {
+                    visitor.visit_u8(v)
+                } else if let Ok(v) = u16::try_from(self.value) {
+                    visitor.visit_u16(v)
+                } else if let Ok(v) = u32::try_from(self.value) {
+                    visitor.visit_u32(v)
+                } else {
+                    visitor.visit_u64(self.value)
+                }
+            }
+            Mode::Widen => visitor.visit_u64(self.value),
+        }
+    }
+
+    fn deserialize_u8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        visitor.visit_u8(self.value as u8)
+    }
+
+    fn deserialize_u16<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        visitor.visit_u16(self.value as u16)
+    }
+
+    fn deserialize_u32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        visitor.visit_u32(self.value as u32)
+    }
+
+    fn deserialize_u64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        visitor.visit_u64(self.value)
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u128 f32 f64 char str string bytes byte_buf
+        option unit unit_struct newtype_struct seq tuple tuple_struct map struct
+        enum identifier ignored_any
+    }
+}
+
+/// pythonize case: a narrowing but hint-honoring deserializer reports `3` as
+/// `visit_u8` from `deserialize_any`, so `MustBe!(3u64)` must request `u64`.
+#[test]
+fn u64_from_narrowing_deserializer() {
+    type Three = MustBe!(3u64);
+    let de = IntDeserializer {
+        value: 3,
+        mode: Mode::Narrow,
+    };
+    Three::deserialize(de).unwrap();
+}
+
+/// cbor4ii case: a widening but hint-honoring deserializer reports `3` as
+/// `visit_u64` from `deserialize_any`, so `MustBe!(3u8)` must request `u8`.
+#[test]
+fn u8_from_widening_deserializer() {
+    type Three = MustBe!(3u8);
+    let de = IntDeserializer {
+        value: 3,
+        mode: Mode::Widen,
+    };
+    Three::deserialize(de).unwrap();
+}
+
+/// Hint-ignoring case: serde's own `U8Deserializer` forwards every method to
+/// `deserialize_any` and reports `visit_u8`. `MustBe!(3u64)` must accept it via
+/// serde's default `visit_u8` -> `visit_u64` forwarding rather than rejecting.
+#[test]
+fn u64_from_hint_ignoring_u8_deserializer() {
+    type Three = MustBe!(3u64);
+    let de: U8Deserializer<Error> = 3u8.into_deserializer();
+    Three::deserialize(de).unwrap();
+}
+
+/// A wrong value must still be rejected.
+#[test]
+fn wrong_value_is_rejected() {
+    type Three = MustBe!(3u64);
+    let de = IntDeserializer {
+        value: 4,
+        mode: Mode::Narrow,
+    };
+    assert!(Three::deserialize(de).is_err());
+}
+
+/// If `zarr_format` were `MustBe!(3)` (-> `MustBePosInt`) instead of
+/// `MustBe!(3u64)`, it survives the untagged `ContentDeserializer` replay:
+/// `MustBePosInt` is value-based (implements `visit_u64`) and has no reject
+/// overrides, so the replayed `visit_u8(3)` forwards up to `visit_u64(3)`.
+#[test]
+fn posint_from_hint_ignoring_u8_deserializer() {
+    type Three = MustBe!(3);
+    let de: U8Deserializer<Error> = 3u8.into_deserializer();
+    Three::deserialize(de).unwrap();
+}


### PR DESCRIPTION
Closes https://github.com/dtolnay/monostate/issues/31

This is my first PR in the serde ecosystem, so I'm not 100% sure if this is the best approach.

I made the changes in deserialize.rs manually.

Claude wrote the tests and I haven't looked at those too closely. If the gist of this PR is acceptable, I can rewrite the tests manually if you'd like.

https://github.com/developmentseed/zarrista/pull/72 is unblocked by patching to the changes here.